### PR TITLE
Configure Eleventy package for Cloudflare Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "cursordemo",
+  "name": "maori-eleventy",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cursordemo",
+      "name": "maori-eleventy",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "UNLICENSED",
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,26 +1,19 @@
 {
-  "name": "cursordemo",
+  "name": "maori-eleventy",
   "version": "1.0.0",
-  "description": "Static site powered by [Eleventy](https://www.11ty.dev/).",
-  "main": ".eleventy.js",
+  "private": true,
+  "description": "Eleventy starter configured for Cloudflare Pages.",
   "scripts": {
+    "dev": "eleventy --serve --watch",
+    "start": "npm run dev",
     "build": "eleventy",
-    "serve": "eleventy --serve",
-    "start": "eleventy --serve",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "preview": "npx wrangler pages dev _site -- npm run build",
+    "deploy": "npx wrangler pages deploy _site"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/eribeiro3478/Maori.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/eribeiro3478/Maori/issues"
-  },
-  "homepage": "https://github.com/eribeiro3478/Maori#readme",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- rename the package and mark it private for a Cloudflare-focused Eleventy starter
- streamline npm scripts for local dev, Cloudflare Pages previews, and deploys
- document the Node.js engine requirement and refresh the lockfile metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9a283be848330bbe8776904ee2f0c